### PR TITLE
long to int (python 3.6) 

### DIFF
--- a/pynigma/client.py
+++ b/pynigma/client.py
@@ -10,7 +10,7 @@ API_VERSION = 'v2'
 # Data type mappings are based on PL/Python PostgreSQL to Python mappings
 # http://www.postgresql.org/docs/9.4/static/plpython-data.html
 _data_type_codec = {
-    'bigint': long,
+    'bigint': int,
     'boolean': bool,
     'bytea': str,
     'character varying': str,
@@ -20,7 +20,7 @@ _data_type_codec = {
     'int': int,
     'integer': int,
     'numeric': decimal.Decimal,
-    'oid': long,
+    'oid': int,
     'real': float,
     'smallint': int,
     'text': str,
@@ -31,8 +31,8 @@ _data_type_codec = {
 
 
 def _map_metadata_data_type(metadata_columns):
-    '''Return the column data from the MetaData endpoint with corresponding 
-    Python data types included. Even though this is used in only one place, it 
+    '''Return the column data from the MetaData endpoint with corresponding
+    Python data types included. Even though this is used in only one place, it
     has been separated out to facilitate testing.
     '''
     for column in metadata_columns:
@@ -51,7 +51,7 @@ class EnigmaAPI(object):
     ---------
     client_key      : a string corresponding to a valid API key
 
-    EXAMPLE 
+    EXAMPLE
     -------
     >>> from pynigma import client
     >>> import os

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Jane Stewart Adams',
     author_email='jane@thejunglejane.com',
     license='MIT',
-    url='https://github.com/annjieching/pynigma',
-    download_url='https://github.com/annjieching/pynigma/tarball/{v}'.format(
+    url='https://github.com/thejunglejane/pynigma',
+    download_url='https://github.com/thejunglejane/pynigma/tarball/{v}'.format(
         v=__version__)
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Jane Stewart Adams',
     author_email='jane@thejunglejane.com',
     license='MIT',
-    url='https://github.com/thejunglejane/pynigma',
-    download_url='https://github.com/thejunglejane/pynigma/tarball/{v}'.format(
+    url='https://github.com/annjieching/pynigma',
+    download_url='https://github.com/annjieching/pynigma/tarball/{v}'.format(
         v=__version__)
 )


### PR DESCRIPTION
Hi Jane, apologies, I'm new to all of this, am not a developer. I installed in on python 3.6 and changed the 2 instances with 'long' to 'int' as it looks like long has been depreciated. But I had another error come up that I'll probably have to spend more time to really understand: 

```
----> 7 data = api.get_data(datapath='us.gov.whitehouse.salaries.2011')
      8 

/Users/annjieching/anaconda/lib/python3.6/site-packages/pynigma/client.py in get_data(self, datapath, **kwargs)
    118         u'position_title': u'REGIONAL COMMUNICATIONS DIRECTOR', u'serialid': 1}
    119         '''
--> 120         return self._request(resource='data', datapath=datapath, **kwargs)
    121 
    122     def get_metadata(self, datapath, **kwargs):

/Users/annjieching/anaconda/lib/python3.6/site-packages/pynigma/client.py in _request(self, resource, datapath, **kwargs)
     92     def _request(self, resource, datapath, **kwargs):
     93         self.request_url = self._url_for_datapath(
---> 94             resource, datapath, **kwargs)
     95         try:
     96             res = requests.get(self.request_url)

/Users/annjieching/anaconda/lib/python3.6/site-packages/pynigma/client.py in _url_for_datapath(self, resource, datapath, **kwargs)
     86             # There is no datapath associated with the limits endpoint.
     87             if datapath:
---> 88                 params = ['='.join([k, v]) for k, v in kwargs.iteritems()]
     89                 return '/'.join([base_url, datapath, '?' + '&'.join(params)])
     90             return base_url

AttributeError: 'dict' object has no attribute 'iteritems'

```

Not sure how you're thinking about pynigma in the future or how you're pulling enigma data. Just thought you might be interested in knowing this. Thank you! 